### PR TITLE
List fix

### DIFF
--- a/snap.py
+++ b/snap.py
@@ -15,13 +15,17 @@ class Snap(dotbot.Plugin):
         
         success = True
         defaults = self._context.defaults().get(self._directive, {})
-
-        for app, options in data.items():
+        for item in data:
 
             classic = defaults.get("classic", False)
+            app = None
 
-            if isinstance(options, dict):
-                classic = options.get("classic", classic)
+            if isinstance(item, Dict):
+                app, options = list(item.items())[0]
+                if options is not None:
+                    classic = options[0].get("classic", classic)
+            else:
+                app = item
             
             try:
                 command = ['snap install']

--- a/snap.py
+++ b/snap.py
@@ -1,13 +1,14 @@
 import subprocess, dotbot
+from typing import List, Dict
 
 class Snap(dotbot.Plugin):
     _directive = 'snap'
 
 
-    def can_handle(self, directive):
+    def can_handle(self, directive: str):
         return self._directive == directive
 
-    def handle(self, directive, data):
+    def handle(self, directive: str , data: List):
         if directive != self._directive:
             raise ValueError('snap cannot handle directive %s' %
                 directive)


### PR DESCRIPTION
I am unsure if there is an issue with python versions or an update to the core dotbot, but this plugin didn't work for me. 

List items parsed to data are either of type ```str``` or ```Dict``` based on the advised config design. #4 suggests forcing all items to be ```Dict``` type, but the ```options``` var was still wrapped in a list which caused the get call to fail. My PR makes it so both of the suggested formats work fine, albeit in a messy way. 